### PR TITLE
fix: 議論グラフの残課題対応 (W1/W2/S1/S2)

### DIFF
--- a/app/api/graph/route.ts
+++ b/app/api/graph/route.ts
@@ -78,6 +78,8 @@ export async function GET(req: NextRequest) {
   let depth = 0;
   const MAX_DEPTH = 10;
   const visitedUp = new Set<string>();
+  // S1: MAX_DEPTH到達時にルートが切り詰められたかを示すフラグ
+  let rootTruncated = false;
 
   while (depth < MAX_DEPTH) {
     if (visitedUp.has(currentId)) {
@@ -98,6 +100,14 @@ export async function GET(req: NextRequest) {
     }
     currentId = post.reply_to;
     depth++;
+  }
+
+  // S1: ループを MAX_DEPTH で抜けた場合、現在のノードがまだ返信であれば切り詰め警告を立てる
+  if (depth >= MAX_DEPTH) {
+    const checkPosts = await fetchPostsByIds([currentId]);
+    if (checkPosts.length > 0 && checkPosts[0].reply_to !== null) {
+      rootTruncated = true;
+    }
   }
 
   const rootId = currentId;
@@ -130,8 +140,9 @@ export async function GET(req: NextRequest) {
         content: post.content,
         created_at: post.created_at,
       });
+      // S2: エッジ方向を 親→子 に修正（reply_to が親）
       if (post.reply_to) {
-        edges.push({ from: post.id, to: post.reply_to });
+        edges.push({ from: post.reply_to, to: post.id });
       }
     }
 
@@ -148,6 +159,11 @@ export async function GET(req: NextRequest) {
       }
     }
     currentLevel = nextLevel;
+  }
+
+  // S1: MAX_DEPTH到達で真のルートに届かなかった場合は warning を付与
+  if (rootTruncated) {
+    return NextResponse.json({ nodes, edges, warning: 'MAX_DEPTH reached: root may be truncated' });
   }
 
   return NextResponse.json({ nodes, edges });

--- a/app/components/DiscussionGraph.tsx
+++ b/app/components/DiscussionGraph.tsx
@@ -25,6 +25,7 @@ interface GraphEdge {
 interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  warning?: string;
 }
 
 interface DiscussionGraphProps {
@@ -54,15 +55,16 @@ function buildLayout(
   const V_GAP = 60;
 
   // 親→子のマップを作成
-  // edges は { from: 子, to: 親 } の形式
+  // edges は { from: 親, to: 子 } の形式（S2対応済み）
   const childrenMap = new Map<string, string[]>();
   const parentMap = new Map<string, string>();
 
   for (const e of graphEdges) {
-    parentMap.set(e.from, e.to);
-    const children = childrenMap.get(e.to) ?? [];
-    children.push(e.from);
-    childrenMap.set(e.to, children);
+    // from=親, to=子 なので parentMap は子→親
+    parentMap.set(e.to, e.from);
+    const children = childrenMap.get(e.from) ?? [];
+    children.push(e.to);
+    childrenMap.set(e.from, children);
   }
 
   // ルートを特定（parentMapに存在しないノード）
@@ -181,9 +183,13 @@ export default function DiscussionGraph({ postId, onClose }: DiscussionGraphProp
     }
   }, [postId]);
 
+  // W2: postId が変わったら loading/error/graphData をリセットしてから再フェッチ
   useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setGraphData(null);
     fetchGraph();
-  }, [fetchGraph]);
+  }, [postId, fetchGraph]);
 
   // Escキーで閉じる
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,7 @@
       "name": "agent-sns",
       "version": "0.1.0",
       "dependencies": {
-        "@dagrejs/dagre": "^3.0.0",
         "@libsql/client": "^0.17.2",
-        "@types/dagre": "^0.7.54",
         "@xyflow/react": "^12.10.2",
         "next": "16.2.2",
         "react": "19.2.4",
@@ -280,21 +278,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
-      }
-    },
-    "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
-      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -1855,12 +1838,6 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
-    },
-    "node_modules/@types/dagre": {
-      "version": "0.7.54",
-      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
-      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "migrate": "node --env-file=.env.local scripts/migrate.mjs"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^3.0.0",
     "@libsql/client": "^0.17.2",
-    "@types/dagre": "^0.7.54",
     "@xyflow/react": "^12.10.2",
     "next": "16.2.2",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary

Issue #5 で管理されていた議論グラフの残課題を対応します。

- W1: `@dagrejs/dagre` / `@types/dagre` を削除（手動レイアウト移行後の未使用依存）
- W2: `DiscussionGraph.tsx` — `postId` 変更時に loading/error/graphData state をリセット
- S1: `route.ts` — MAX_DEPTH 到達時、真のルートでない場合に `warning` フィールドを返す
- S2: `route.ts` — エッジ方向を `子→親` から `親→子` に修正。フロント側の `buildLayout` のコメントと childrenMap/parentMap ロジックも更新

## Test plan

- [ ] `npm run build` が通ること（TypeScript コンパイル・型チェックは通過済み）
- [ ] 議論グラフが正常に表示されること（ReactFlow エッジが親→子方向）
- [ ] 異なる postId を連続して開いたとき前の loading/error がリセットされること
- [ ] `@dagrejs/dagre` が `package.json` から消えていること

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)