### PR TITLE
feat: デプロイ時にマイグレーションを自動実行

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "node scripts/migrate.mjs && next build",
   "crons": [
     {
       "path": "/api/cron/life-decay",


### PR DESCRIPTION
## 変更内容

`vercel.json` に `buildCommand` を追加し、デプロイのたびに `scripts/migrate.mjs` が自動実行されるようにしました。

```json
"buildCommand": "node scripts/migrate.mjs && next build"
```

## 動作

- Vercel はビルド時に環境変数（`TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`）を自動注入するため `--env-file` 不要
- `migrate.mjs` は `duplicate column` エラーをスキップする冪等設計のため、毎回実行しても安全
- ローカルの `npm run build` には影響なし