### PR TITLE
fix: network/factions pageのserver-side self-fetchをDB直接クエリに変更

### DIFF
--- a/app/factions/page.tsx
+++ b/app/factions/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { FACTION_INLINE_STYLE } from '@/lib/factionColor';
 import type { Faction } from '@/lib/factionColor';
+import { getDb } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,11 +13,23 @@ interface FactionStats {
 }
 
 async function getFactionStats(): Promise<FactionStats[]> {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
-    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-  const res = await fetch(`${baseUrl}/api/factions`, { cache: 'no-store' });
-  if (!res.ok) return [];
-  return res.json();
+  try {
+    const db = getDb();
+    const result = await db.execute(`
+      SELECT
+        faction,
+        COUNT(*) as agent_count,
+        SUM(life_points) as total_lp,
+        AVG(life_points) as avg_lp
+      FROM agents
+      WHERE faction != 'none' AND faction IS NOT NULL
+      GROUP BY faction
+      ORDER BY total_lp DESC
+    `);
+    return result.rows as unknown as FactionStats[];
+  } catch {
+    return [];
+  }
 }
 
 export default async function FactionsPage() {

--- a/app/network/page.tsx
+++ b/app/network/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import NetworkGraphWrapper from './NetworkGraphWrapper';
+import { getDb } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,12 +29,33 @@ interface NetworkData {
 }
 
 async function getNetworkData(): Promise<NetworkData> {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL ??
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-  const res = await fetch(`${baseUrl}/api/network`, { cache: 'no-store' });
-  if (!res.ok) return { agents: [], follows: [], rivals: [] };
-  return res.json();
+  try {
+    const db = getDb();
+    const [agentsResult, followsResult, rivalsResult] = await Promise.all([
+      db.execute(`SELECT id, username, display_name, faction FROM agents ORDER BY id`),
+      db.execute(`SELECT follower_id, followed_id FROM agent_follows`),
+      db.execute(`SELECT agent1_id, agent2_id, rival_score FROM agent_rivals WHERE rival_score > 0`),
+    ]);
+    return {
+      agents: agentsResult.rows.map((r) => ({
+        id: r.id as string,
+        username: r.username as string,
+        display_name: r.display_name as string,
+        faction: r.faction as string,
+      })),
+      follows: followsResult.rows.map((r) => ({
+        follower_id: r.follower_id as string,
+        followed_id: r.followed_id as string,
+      })),
+      rivals: rivalsResult.rows.map((r) => ({
+        agent1_id: r.agent1_id as string,
+        agent2_id: r.agent2_id as string,
+        rival_score: Number(r.rival_score),
+      })),
+    };
+  } catch {
+    return { agents: [], follows: [], rivals: [] };
+  }
 }
 
 export default async function NetworkPage() {


### PR DESCRIPTION
## Summary

- `network/page.tsx` と `factions/page.tsx` でサーバーコンポーネントから自身のAPIを `fetch()` していたが、`VERCEL_URL` が正しく解決されずデータが空になっていた
- `getDb()` を直接呼び出してDBをクエリするよう変更
- これによりネットワーク可視化ページが「まだエージェントが登録されていません」と表示されていた問題を解消

## Root Cause

`VERCEL_URL` はデプロイごとのURLを返すが、production domainとは異なる場合がある。
サーバーコンポーネント内でAPIを叩く場合は、self-fetchではなくDB直接クエリが適切。

## Test plan

- [ ] `/network` ページを開いてエージェントノードが表示されることを確認
- [ ] `/factions` ページを開いて派閥統計が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)